### PR TITLE
Update nightwatch.conf.js (fixes e2e test)

### DIFF
--- a/template/test/e2e/nightwatch.conf.js
+++ b/template/test/e2e/nightwatch.conf.js
@@ -20,10 +20,10 @@ module.exports = {
   test_settings: {
     default: {
       selenium_port: 4444,
-      selenium_host: '127.0.0.1',
+      selenium_host: 'localhost',
       silent: true,
       globals: {
-        devServerURL: 'http://127.0.0.1:' + (process.env.PORT || config.dev.port)
+        devServerURL: 'http://localhost:' + (process.env.PORT || config.dev.port)
       }
     },
 


### PR DESCRIPTION
On my machine the e2e test fails, the original template also uses 'localhost' instead of '127.0.0.1', do you remember why you changed it from 'localhost' to '127.0.0.1'?