### PR TITLE
Enable type checking with tslint

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -69,7 +69,8 @@ module.exports = {
         include: [resolve('src'),{{#if_eq projectType "lib"}} resolve('app'),{{/if_eq}} resolve('test')],
         options: {
           formatter: 'grouped',
-          formattersDirectory: 'node_modules/custom-tslint-formatters/formatters'
+          formattersDirectory: 'node_modules/custom-tslint-formatters/formatters',
+          typeCheck: true
         }
       },
       {{/tslint}}

--- a/template/package.json
+++ b/template/package.json
@@ -21,7 +21,7 @@
     {{/if_or}}
     {{#lint}}
     "lint": "eslint --ext .js,.vue src{{#unit}} test/unit/specs{{/unit}}{{#e2e}} test/e2e/specs{{/e2e}}",{{/lint}}{{#tslint}}
-    "tslint": "tslint -s node_modules/custom-tslint-formatters/formatters -t grouped 'src/**/*.ts'{{#unit}} 'test/unit/**/*.ts'{{/unit}}{{#e2e}} 'test/e2e/*.ts'{{/e2e}}",{{/tslint}}
+    "tslint": "tslint -p . -s node_modules/custom-tslint-formatters/formatters -t grouped 'src/**/*.ts'{{#unit}} 'test/unit/**/*.ts'{{/unit}}{{#e2e}} 'test/e2e/*.ts'{{/e2e}}",{{/tslint}}
     "build": "node build/build.js"
   },
   "dependencies": {


### PR DESCRIPTION
On a fresh out of the oven (template) project, I run `npm run tslint` and returns the following:
```
toilal\my-project> npm run tslint

> my-project@1.0.0 tslint C:\Users\bart.ledoux\Documents\GitHub\toilal\my-project
> tslint -s node_modules/custom-tslint-formatters/formatters -t grouped 'src/**/*.ts' 'test/unit/**/*.ts'

Warning: The 'await-promise' rule requires type information.
Warning: The 'no-unused-variable' rule requires type information.
Warning: The 'no-use-before-declare' rule requires type information.
Warning: The 'return-undefined' rule requires type information.
Warning: The 'no-floating-promises' rule requires type information.
Warning: The 'no-unnecessary-qualifier' rule requires type information.
Warning: The 'strict-type-predicates' rule requires type information.
```

The issue is very simple : in order for tslint to work with those standard rules, its needs to access ythe tsconfig.json... And it is very bad at guessing! so one has to tell it where the file is...

What do you think ?